### PR TITLE
Fixed syntax of SYNOPSIS

### DIFF
--- a/lib/AHA.pm
+++ b/lib/AHA.pm
@@ -4,7 +4,7 @@ AHA - Simple access to the AHA interface for AVM based home automation
 
 =head1 SYNOPSIS
 
-    my $aha = new AHA({host: "fritz.box", password: "s!cr!t"});
+    my $aha = AHA->new( { host => "fritz.box", password => "s!cr!t" } );
 
     # Get all switches as array ref of AHA::Switch objects
     my $switches = $aha->list();


### PR DESCRIPTION
The object creation in the SYNOPSIS of version 0.55 did not contain valid Perl code (`:`s instead of `=>`s).
I also removed the indirect object syntax in this place, because [it's kind of deprecated now](https://perldoc.perl.org/perlobj#Indirect-Object-Syntax).