### PR TITLE
Added git repository URL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -22,6 +22,11 @@ my $build = Module::Build->new
                       "Test::More" => "0",
                      },                       
    configure_requires => { 'Module::Build' => 0.34 },
+   meta_add => {
+       resources => {
+           repository => 'https://github.com/rhuss/aha',
+       },
+   },
    keywords => [  "AVM", "AHA", "Fritz", "Dect!200" ]
   );
 


### PR DESCRIPTION
Adds the git repository URL to Build.PL which should make it visible on the [meta::cpan page of the module](https://metacpan.org/pod/AHA) once the new version has been uploaded.

Disclaimer: I could not test this; I just borrowed the syntax from other modules like [Net::IDN::Encode](https://metacpan.org/release/Net-IDN-Encode/source/Build.PL).