### PR TITLE
Fixed syntax of example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information, see the manpage to AHA.
 ### Example
 
 ````perl
-    my $aha = new AHA({host: "fritz.box", password: "s!cr!t"});
+    my $aha = AHA->new( { host => "fritz.box", password => "s!cr!t" } );
 
     # Get all switches as array ref of AHA::Switch objects
     my $switches = $aha->list();


### PR DESCRIPTION
basically the same syntax fix for the example code as in the SYNOPSIS last year, now for the README